### PR TITLE
Support React 15 Peer Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "peerDependencies": {
     "classnames": "^2.2.3",
-    "react": "^0.14.7"
+    "react": "0.14.x || 15.x.x"
   },
   "devDependencies": {
     "autoprefixer": "^6.3.3",


### PR DESCRIPTION
Support React version 15 to remove failed peer dependency warning.

```
~/r/alekseynikolsky.com git:master ❯❯❯ npm i --save react-responsive-audio-player                                        
alekseynikolsky.com@0.1.0 /Users/andrewzey/Repos/alekseynikolsky.com
├── UNMET PEER DEPENDENCY react@15.3.2
└── react-responsive-audio-player@0.3.0

npm WARN react-responsive-audio-player@0.3.0 requires a peer of react@^0.14.7 but none was installed.
```