### PR TITLE
If new playlist passed by prop contains current track, continue playback.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react": "0.14.x || 15.x.x"
   },
   "devDependencies": {
+    "array-find-index": "^1.0.2",
     "autoprefixer": "^6.3.3",
     "babel-core": "^6.7.2",
     "babel-loader": "^6.2.4",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 const React = require('react');
+const arrayFindIndex = require('array-find-index');
 const classNames = require('classnames');
 
 const log = console.log.bind(console);
@@ -137,11 +138,24 @@ class AudioPlayer extends React.Component {
   }
 
   componentWillReceiveProps (nextProps) {
-    if (!nextProps.playlist) {
-      return;
-    }
+    const currentTrackUrl = (
+      (this.playlist || [])[this.currentTrackIndex] || {}
+    ).url;
     this.playlist = nextProps.playlist;
-    this.currentTrackIndex = -1;
+    this.currentTrackIndex = arrayFindIndex((this.playlist || []), track => {
+      return track.url && currentTrackUrl === track.url;
+    });
+    /* if the track we're already playing is in the new playlist, update the
+     * activeTrackIndex and we're done.
+     */
+    if (this.currentTrackIndex !== -1) {
+      return this.setState({
+        activeTrackIndex: this.currentTrackIndex
+      });
+    }
+    /* otherwise, if our audio element is available, pause and queue up
+     * the new first track.
+     */
     if (this.audio) {
       this.skipToNextTrack(false);
     }


### PR DESCRIPTION
Previously, a prop update would result in the player pausing and the current track index being reset.

This is undesired behavior since prop updates can and will happen all the time (my fault for not testing the player in a larger project with many components).

Now, playback will ALWAYS continue unless the new playlist does not contain the current track. The current track index is updated so the next track will be the next song in the NEW playlist order, after the one that had been playing. If the currently playing track isn't found in the new playlist, then playback is paused and the current track is reset (as before).

One significant breaking change is that previously, a prop update in which the playlist becomes falsy would be ignored (playback would just continue with the previously-specified playlist). This turns out not to be particularly desirable. If no playlist is passed, it was probably on purpose and the player should react accordingly (by stopping).

Now if a `null` playlist is provided the player will display a message asking the user to load a playlist.