### PR TITLE
Remove fixed position default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -322,7 +322,8 @@ class AudioPlayer extends React.Component {
     return (
       <div id="audio_player"
            className={ classNames('audio_player', { 'top': this.props.placeAtTop }) }
-           title={ displayText }>
+           title={ displayText }
+           style={ this.props.style }>
 
         <div className="audio_controls">
           <div id="skip_button"
@@ -394,7 +395,8 @@ AudioPlayer.propTypes = {
   gapLengthInSeconds: React.PropTypes.number,
   hideBackSkip: React.PropTypes.bool,
   stayOnBackSkipThreshold: React.PropTypes.number,
-  placeAtTop: React.PropTypes.bool
+  placeAtTop: React.PropTypes.bool,
+  style: React.PropTypes.object
 };
 
 module.exports = AudioPlayer;

--- a/src/index.scss
+++ b/src/index.scss
@@ -60,8 +60,6 @@
   flex-direction: row;
   height: 50px;
   background-color: #333;
-  position: fixed;
-  bottom: 0;
   width: 100%;
 
   &.top {


### PR DESCRIPTION
As suggested by @andrewzey in https://github.com/benwiley4000/react-responsive-audio-player/issues/6, the default `position: fixed; bottom: 0` style applied to the `.audio_player` element makes the component less modular/portable. Those styles are now removed, and instead one may either apply those or similar styles via CSS, or by passing a React `style` object as a prop to the component.

e.g.
```
<AudioPlayer
  playlist={playlist}
  style={{ position: 'fixed', bottom: 0 }} />
```