### PR TITLE
Fix Audio Progress Bar Bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -275,7 +275,11 @@ class AudioPlayer extends React.Component {
      * after touch handlers if we're seeking.
      */
     event.preventDefault();
-    const boundingRect = this.audioProgressBoundingRect;
+    /* Needs to be called here again, because the click handler is bound
+	   * at the same time as the ref, so this.audioProgressContainer size
+	   * isn't updated yet, since that happens in componentDidMount
+     */
+    const boundingRect = this.audioProgressContainer.getBoundingClientRect();
     const isTouch = event.type.slice(0, 5) === 'touch';
     const pageX = isTouch ? event.targetTouches.item(0).pageX : event.pageX;
     const position = pageX - boundingRect.left - document.body.scrollLeft;


### PR DESCRIPTION
Fixes bug where on initial page load, the audio progress bar click handler results in the bar seeking to a position other than where the user has clicked.

Video of Bug: https://www.dropbox.com/s/4w23kctxos7zn31/Bug%20Fix%20Video.mov?dl=0