### PR TITLE
Add new props repeat, disableSeek, hideForwardSkip

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Options can be passed to the AudioPlayer element as props. Currently supported p
 
 * `disableSeek`: a boolean value that if true prevents seeking. **false** by default.
 
-* `repeat`: a boolean value that if true continues playing from the beginning after the playlist has completed. **true** by default.
+* `cycle`: a boolean value that if true continues playing from the beginning after the playlist has completed. **true** by default.
 
 * `stayOnBackSkipThreshold`: a number value that represents the number of seconds of progress after which pressing the back button will simply restart the current track. **5** by default.
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ Options can be passed to the AudioPlayer element as props. Currently supported p
 
 * `hideBackSkip`: a boolean value that if true disables the back skip button by hiding it from view. **false** by default.
 
+* `hideForwardSkip`: a boolean value that if true disables the forward skip button by hiding it from view. **false** by default.
+
+* `disableSeek`: a boolean value that if true prevents seeking. **false** by default.
+
+* `repeat`: a boolean value that if true continues playing from the beginning after the playlist has completed. **true** by default.
+
 * `stayOnBackSkipThreshold`: a number value that represents the number of seconds of progress after which pressing the back button will simply restart the current track. **5** by default.
 
 * `style`: a React style object which is applied to the outermost div in the component. **undefined** be default.

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,15 @@ function convertToTime (number) {
  * Accepts 'hideBackSkip' prop (default false,
  * hides back skip button if true).
  *
+ * Accepts 'hideForwardSkip' prop (default false,
+ * hides forward skip button if true).
+ *
+ * Accepts 'disableSeek' prop (default false,
+ * disables seeking through the audio if true).
+ *
+ * Accepts 'repeat' prop (default true,
+ * repeats the playlist when finished if true).
+ *
  * Accepts 'stayOnBackSkipThreshold' prop, default 5,
  * is number of seconds to progress until pressing back skip
  * restarts the current track.
@@ -71,7 +80,7 @@ class AudioPlayer extends React.Component {
        * the new time is visually previewed before the
        * audio seeks.
        */
-      displayedTime: 0 
+      displayedTime: 0
     };
 
     this.state = this.defaultState;
@@ -216,6 +225,7 @@ class AudioPlayer extends React.Component {
       displayedTime: 0
     }, () => {
       this.updateSource();
+      if (i === 0 && !this.props.repeat) shouldPlay = false;
       const shouldPause = typeof shouldPlay === 'boolean' ? !shouldPlay : false;
       this.togglePause(shouldPause);
     });
@@ -258,7 +268,7 @@ class AudioPlayer extends React.Component {
   }
 
   adjustDisplayedTime (event) {
-    if (!this.props.playlist || !this.props.playlist.length) {
+    if (!this.props.playlist || !this.props.playlist.length || this.props.disableSeek) {
       return;
     }
     // make sure we don't select stuff in the background while seeking
@@ -358,7 +368,9 @@ class AudioPlayer extends React.Component {
           </div>
           <div
             id="skip_button"
-            className="skip_button audio_button"
+            className={classNames('skip_button audio_button', {
+              'hidden': this.props.hideForwardSkip
+            })}
             onClick={() => this.skipToNextTrack()}
           >
             <div className="skip_button_inner">
@@ -409,8 +421,15 @@ AudioPlayer.propTypes = {
   autoplayDelayInSeconds: React.PropTypes.number,
   gapLengthInSeconds: React.PropTypes.number,
   hideBackSkip: React.PropTypes.bool,
+  hideForwardSkip: React.PropTypes.bool,
+  repeat: React.PropTypes.bool,
+  disableSeek: React.PropTypes.bool,
   stayOnBackSkipThreshold: React.PropTypes.number,
   style: React.PropTypes.object
+};
+
+AudioPlayer.defaultProps = {
+  repeat: true
 };
 
 module.exports = AudioPlayer;

--- a/src/index.js
+++ b/src/index.js
@@ -44,8 +44,9 @@ function convertToTime (number) {
  * Accepts 'disableSeek' prop (default false,
  * disables seeking through the audio if true).
  *
- * Accepts 'repeat' prop (default true,
- * repeats the playlist when finished if true).
+ * Accepts 'cycle' prop (default true,
+ * starts playing at the beginning of the playlist
+ * when finished if true).
  *
  * Accepts 'stayOnBackSkipThreshold' prop, default 5,
  * is number of seconds to progress until pressing back skip
@@ -225,8 +226,8 @@ class AudioPlayer extends React.Component {
       displayedTime: 0
     }, () => {
       this.updateSource();
-      if (i === 0 && !this.props.repeat) shouldPlay = false;
-      const shouldPause = typeof shouldPlay === 'boolean' ? !shouldPlay : false;
+      const shouldCycle = (this.props.cycle && i === 0);
+      const shouldPause = !shouldCycle || (typeof shouldPlay === 'boolean' ? !shouldPlay : false);
       this.togglePause(shouldPause);
     });
   }
@@ -422,14 +423,14 @@ AudioPlayer.propTypes = {
   gapLengthInSeconds: React.PropTypes.number,
   hideBackSkip: React.PropTypes.bool,
   hideForwardSkip: React.PropTypes.bool,
-  repeat: React.PropTypes.bool,
+  cycle: React.PropTypes.bool,
   disableSeek: React.PropTypes.bool,
   stayOnBackSkipThreshold: React.PropTypes.number,
   style: React.PropTypes.object
 };
 
 AudioPlayer.defaultProps = {
-  repeat: true
+  cycle: true
 };
 
 module.exports = AudioPlayer;


### PR DESCRIPTION
Hey! Neat project. I have added a few new options for my own needs, and I thought I would give you the option of merging them for others to use if you felt it was appropriate. I have one more change in mind, but it is unrelated so I will open a separate PR for it soon.

These are the options I added.

* `hideForwardSkip`: a boolean value that if true disables the forward skip button by hiding it from view. **false** by default.
* `disableSeek`: a boolean value that if true prevents seeking. **false** by default.
* `repeat`: a boolean value that if true continues playing from the beginning after the playlist has completed. **true** by default.

I have tested these changes locally without issue. I'm happy to change or remove any of the options as well if you don't want all of them.