### PR TITLE
Add callbacks for when a track has started and completed

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,13 @@ Options can be passed to the AudioPlayer element as props. Currently supported p
 
 * `stayOnBackSkipThreshold`: a number value that represents the number of seconds of progress after which pressing the back button will simply restart the current track. **5** by default.
 
-* `style`: a React style object which is applied to the outermost div in the component. **undefined** be default.
+* `style`: a React style object which is applied to the outermost div in the component. **undefined** by default.
 
-None of these options is required, though the player will be functionally disabled if no `playlist` prop is provided.
+* `onTrackStart`: A function callback that is invoked when a track begins playing. An argument will be provided to the callback representing the track that has been started. **undefined** by default.
+
+* `onTrackEnd`: A function callback that is invoked when a track completely finishes playing. An argument will be provided to the callback representing the track that has completely finished playing. **undefined** by default.
+
+None of these options are required, though the player will be functionally disabled if no `playlist` prop is provided.
 
 ##Styling
 **IMPORTANT NOTES**

--- a/example.html
+++ b/example.html
@@ -10,7 +10,7 @@
       body {
         margin: 0;
         background: gold;
-      } 
+      }
       .demo {
         font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
       }
@@ -51,7 +51,9 @@
         React.createElement(AudioPlayer, {
           playlist: playlist,
           autoplay: true,
-          style: { position: 'fixed', bottom: 0 }
+          style: { position: 'fixed', bottom: 0 },
+          onTrackStart: (track) => { console.log(`${track.displayText} has started`) },
+          onTrackEnd: (track) => { console.log(`${track.displayText} has ended`) }
         }),
         document.getElementById('audio_player_container')
       );


### PR DESCRIPTION
This commit adds two new options to react-responsive-audio-player: `onTrackStart`, and `onTrackEnd`. These callbacks allow any parent components to know when the AudioPlayer has started, or completed a track. 

Ultimately it might be nice if they could know even more than that, for example; when a user pauses, skips forward/back, when the playlist as a whole has completed, and when the user has clicked to seek. For now I have only added the aforementioned two.