### PR TITLE
Add onMediaEvent prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,11 @@ Options can be passed to the AudioPlayer element as props. Currently supported p
 
 * `stayOnBackSkipThreshold`: a number value that represents the number of seconds of progress after which pressing the back button will simply restart the current track. **5** by default.
 
-* `style`: a React style object which is applied to the outermost div in the component. **undefined** be default.
+* `style`: a React style object which is applied to the outermost div in the component. **undefined** by default.
 
-None of these options is required, though the player will be functionally disabled if no `playlist` prop is provided.
+* `onMediaEvent`: An object where the keys are [media event types](https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Media_events) and the values are callback functions. **undefined** by default.
+
+None of these options are required, though the player will be functionally disabled if no `playlist` prop is provided.
 
 ##Styling
 **IMPORTANT NOTES**

--- a/example.html
+++ b/example.html
@@ -10,7 +10,7 @@
       body {
         margin: 0;
         background: gold;
-      } 
+      }
       .demo {
         font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
       }
@@ -51,7 +51,15 @@
         React.createElement(AudioPlayer, {
           playlist: playlist,
           autoplay: true,
-          style: { position: 'fixed', bottom: 0 }
+          style: { position: 'fixed', bottom: 0 },
+          onMediaEvent: {
+            'playing': function(e) {
+              console.log('Playback has started');
+            },
+            'pause': function(e) {
+              console.log('Playback was paused');
+            }
+          }
         }),
         document.getElementById('audio_player_container')
       );

--- a/src/index.js
+++ b/src/index.js
@@ -152,7 +152,7 @@ class AudioPlayer extends React.Component {
   }
 
   componentWillReceiveProps (nextProps) {
-    // Update media event listeners that may have cchanged
+    // Update media event listeners that may have changed
     this.removeMediaEventListeners(this.props.onMediaEvent);
     this.addMediaEventListeners(nextProps.onMediaEvent);
 
@@ -185,18 +185,24 @@ class AudioPlayer extends React.Component {
     if (!mediaEvents) {
       return;
     }
-    for (let type in mediaEvents) {
+    Object.keys(mediaEvents).forEach((type) => {
+      if (typeof mediaEvents[type] !== 'function') {
+        return;
+      }
       this.audio.addEventListener(type, mediaEvents[type]);
-    }
+    });
   }
 
   removeMediaEventListeners (mediaEvents) {
     if (!mediaEvents) {
       return;
     }
-    for (let type in mediaEvents) {
+    Object.keys(mediaEvents).forEach((type) => {
+      if (typeof mediaEvents[type] !== 'function') {
+        return;
+      }
       this.audio.removeEventListener(type, mediaEvents[type]);
-    }
+    });
   }
 
   componentDidUpdate () {


### PR DESCRIPTION
This PR adds the `onMediaEvent` prop which allows users to listen to media events on the underlying audio element as dicussed in #19.