### PR TITLE
Better listener management

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -131,6 +131,11 @@ class AudioPlayer extends React.Component {
         paused: false
       });
     });
+    audio.addEventListener('pause', () => {
+      this.setState({
+        paused: true
+      });
+    });
     audio.addEventListener('stalled', () => this.togglePause(true));
     if (this.props.playlist && this.props.playlist.length) {
       this.updateSource();
@@ -231,10 +236,7 @@ class AudioPlayer extends React.Component {
     }
     const pause = typeof value === 'boolean' ? value : !this.state.paused;
     if (pause) {
-      this.audio.pause();
-      return this.setState({
-        paused: true
-      });
+      return this.audio.pause();
     }
     if (!this.props.playlist || !this.props.playlist.length) {
       return;


### PR DESCRIPTION
Includes a couple of patches to make audio element listeners work better with [`audioElementRef`](https://github.com/benwiley4000/react-responsive-audio-player/commit/a8b35ffe5959880dd9a316115e9e77a171f47215):

* Fixes #24: Previously we optimistically updated the state to `paused: true` whenever the pause button was clicked. Now that the audio element can be exposed and manipulated via `audioElementRef` this isn't so good; the audio element could be paused and our component wouldn't know. Now the state updates to `paused: true` in response to (and only in response to) the audio element's `pause` event.
* Previously we didn't unbind internal audio element listeners on unmount, since the assumption was the element would be garbage-collected soon enough. However since the audio element reference could now outlast the component lifecycle we need to make sure those listeners are unbound before unmount.