### PR TITLE
For #29, added prop-types as external library for upcoming React 16.x

### DIFF
--- a/example.html
+++ b/example.html
@@ -27,9 +27,10 @@
       <div id="audio_player_container"></div>
     </main>
 
-    <!-- react/react-dom served over CDN -->
+    <!-- react/react-dom/prop-types served over CDN -->
     <script src="https://unpkg.com/react@15/dist/react.js"></script>
     <script src="https://unpkg.com/react-dom@15/dist/react-dom.js"></script>
+    <script src="https://unpkg.com/prop-types/prop-types.js"></script>
 
     <script src="dist/audioplayer.js"></script>
     <script>

--- a/package.json
+++ b/package.json
@@ -52,5 +52,8 @@
     "style-loader": "^0.13.0",
     "webpack": "^1.12.14",
     "webpack-dev-server": "^1.16.2"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.10"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import arrayFindIndex from 'array-find-index';
 import classNames from 'classnames';
 
@@ -471,18 +472,18 @@ class AudioPlayer extends React.Component {
 }
 
 AudioPlayer.propTypes = {
-  playlist: React.PropTypes.array,
-  autoplay: React.PropTypes.bool,
-  autoplayDelayInSeconds: React.PropTypes.number,
-  gapLengthInSeconds: React.PropTypes.number,
-  hideBackSkip: React.PropTypes.bool,
-  hideForwardSkip: React.PropTypes.bool,
-  cycle: React.PropTypes.bool,
-  disableSeek: React.PropTypes.bool,
-  stayOnBackSkipThreshold: React.PropTypes.number,
-  style: React.PropTypes.object,
-  onMediaEvent: React.PropTypes.object,
-  audioElementRef: React.PropTypes.func
+  playlist: PropTypes.array,
+  autoplay: PropTypes.bool,
+  autoplayDelayInSeconds: PropTypes.number,
+  gapLengthInSeconds: PropTypes.number,
+  hideBackSkip: PropTypes.bool,
+  hideForwardSkip: PropTypes.bool,
+  cycle: PropTypes.bool,
+  disableSeek: PropTypes.bool,
+  stayOnBackSkipThreshold: PropTypes.number,
+  style: PropTypes.object,
+  onMediaEvent: PropTypes.object,
+  audioElementRef: PropTypes.func
 };
 
 AudioPlayer.defaultProps = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,6 +35,12 @@ var webpackConfig = {
     return [autoprefixer({ browsers: ['> 2%'] })];
   },
   externals: {
+    'prop-types': {
+      root: 'PropTypes',
+      commonjs: 'prop-types',
+      commonjs2: 'prop-types',
+      amd: 'prop-types'
+    },
     'react': {
       root: 'React',
       commonjs: 'react',


### PR DESCRIPTION
Closes #29

I was not able to test this change.

The only issue I can foresee is with older versions of React.

'What happens on other React versions?
It outputs warnings with the message below even though the developer doesn’t do anything wrong. Unfortunately there is no solution for this other than updating React to either 15.3.0 or higher, or 0.14.9 if you’re using React 0.14.'