### PR TITLE
Make player controls more accessible

### DIFF
--- a/src/controls/PlayPauseButton.js
+++ b/src/controls/PlayPauseButton.js
@@ -8,7 +8,7 @@ class PlayPauseButton extends PurePropTypesComponent {
   render () {
     const { paused, awaitingResumeOnSeekComplete, onTogglePause } = this.props;
     return (
-      <div
+      <button
         className={classNames(
           'rrap__play_pause_button rrap__audio_button',
           { paused: paused && !awaitingResumeOnSeekComplete }
@@ -21,7 +21,7 @@ class PlayPauseButton extends PurePropTypesComponent {
           <div className="triangle_1"></div>
           <div className="triangle_2"></div>
         </div>
-      </div>
+      </button>
     );
   }
 }

--- a/src/controls/RepeatButton.js
+++ b/src/controls/RepeatButton.js
@@ -33,7 +33,7 @@ class RepeatButton extends PurePropTypesComponent {
     const { repeatStrategy } = this.props;
     const Icon = repeatStrategy === 'track' ? RepeatOneIcon : RepeatIcon;
     return (
-      <div
+      <button
         className={classNames(
           'rrap__material_toggle rrap__audio_button rrap__repeat_btn',
           { on: repeatStrategy !== 'none' }
@@ -43,7 +43,7 @@ class RepeatButton extends PurePropTypesComponent {
         <div className="inner foreground">
           <Icon width="100%" height="100%" />
         </div>
-      </div>
+      </button>
     );
   }
 }

--- a/src/controls/ShuffleButton.js
+++ b/src/controls/ShuffleButton.js
@@ -9,7 +9,7 @@ class ShuffleButton extends PurePropTypesComponent {
   render () {
     const { shuffle, onToggleShuffle } = this.props;
     return (
-      <div
+      <button
         className={classNames(
           'rrap__material_toggle rrap__audio_button rrap__shuffle_btn',
           { on: shuffle }
@@ -19,7 +19,7 @@ class ShuffleButton extends PurePropTypesComponent {
         <div className="inner foreground">
           <ShuffleIcon width="100%" height="100%" />
         </div>
-      </div>
+      </button>
     );
   }
 }

--- a/src/controls/VolumeControl.js
+++ b/src/controls/VolumeControl.js
@@ -173,7 +173,7 @@ class VolumeControl extends PurePropTypesComponent {
         onMouseLeave={this.handleMouseLeave}
         onTouchStart={stopPropagation}
       >
-        <div
+        <button
           ref={this.setMuteToggleRef}
           className={classNames(
             'button rrap__audio_button',
@@ -185,7 +185,7 @@ class VolumeControl extends PurePropTypesComponent {
             'foreground',
             getVolumeIconClassName(volume, muted)
           )} />
-        </div>
+        </button>
         {volumeBarPosition && (
           <div
             ref={this.setVolumeBarContainerRef}

--- a/src/controls/common/SkipButton.js
+++ b/src/controls/common/SkipButton.js
@@ -8,7 +8,7 @@ class SkipButton extends PurePropTypesComponent {
   render () {
     const { back, onClick } = this.props;
     return (
-      <div
+      <button
         className={classNames(
           'rrap__skip_button rrap__audio_button',
           { back }
@@ -20,7 +20,7 @@ class SkipButton extends PurePropTypesComponent {
           <div className="right_facing_triangle"></div>
           <div className="vertical_bar"></div>
         </div>
-      </div>
+      </button>
     );
   }
 }

--- a/src/styles/_MaterialToggleButton.scss
+++ b/src/styles/_MaterialToggleButton.scss
@@ -5,6 +5,8 @@
 .rrap {
 
   &__material_toggle {
+    background: none;
+    border: none;
 
     .inner {
       margin-left: -8px;

--- a/src/styles/_PlayPauseButton.scss
+++ b/src/styles/_PlayPauseButton.scss
@@ -4,6 +4,8 @@
 
   /* http://codepen.io/aralon/pen/NqGWXZ */
   &__play_pause_button {
+    background: none;
+    border: none;
 
     .play_pause_inner {
       height: $rrap_play_btn_inner_height;

--- a/src/styles/_SkipButton.scss
+++ b/src/styles/_SkipButton.scss
@@ -3,6 +3,8 @@
 .rrap {
 
   &__skip_button {
+    background: none;
+    border: none;
 
     &.back {
       transform: rotate(180deg);

--- a/src/styles/_VolumeControl.scss
+++ b/src/styles/_VolumeControl.scss
@@ -7,6 +7,8 @@
     position: relative;
 
     .button {
+      background: none;
+      border: none;
       width: $rrap_volume_btn_width;
 
       [class*='icono-volume'] {


### PR DESCRIPTION
Currently you can't keyboard navigate through the player controls, this solves that.

![](https://d1ax1i5f2y3x71.cloudfront.net/items/1n1o05350r0Q1k3F3w07/Screen%20Recording%202017-09-10%20at%2005.51%20PM.gif)
