### PR TITLE
Testing a technique for reducing bundle size with utils for function binding and event listeners

### DIFF
--- a/src/AudioPlayer.js
+++ b/src/AudioPlayer.js
@@ -15,6 +15,8 @@ import getDisplayText from './utils/getDisplayText';
 import getRepeatStrategy from './utils/getRepeatStrategy';
 import getControlRenderProp from './utils/getControlRenderProp';
 import convertToNumberWithinIntervalBounds from './utils/convertToNumberWithinIntervalBounds';
+import bindMethods from './utils/bindMethods';
+import { addListenersOnObject, removeListenersOnObject } from './utils/listeners';
 import { repeatStrategyOptions } from './constants';
 
 import './styles/index.scss';
@@ -132,35 +134,37 @@ class AudioPlayer extends Component {
     // html audio element used for playback
     this.audio = null;
 
-    // bind methods fired on React events
-    this.setAudioElementRef = this.setAudioElementRef.bind(this);
-    this.togglePause = this.togglePause.bind(this);
-    this.selectTrackIndex = this.selectTrackIndex.bind(this);
-    this.forwardSkip = this.forwardSkip.bind(this);
-    this.backSkip = this.backSkip.bind(this);
-    this.seekPreview = this.seekPreview.bind(this);
-    this.seekComplete = this.seekComplete.bind(this);
-    this.setVolume = this.setVolume.bind(this);
-    this.setVolumeComplete = this.setVolumeComplete.bind(this);
-    this.toggleMuted = this.toggleMuted.bind(this);
-    this.toggleShuffle = this.toggleShuffle.bind(this);
-    this.setRepeatStrategy = this.setRepeatStrategy.bind(this);
-    this.setPlaybackRate = this.setPlaybackRate.bind(this);
+    bindMethods(this, [
+      // bind methods fired on React events
+      'setAudioElementRef',
+      'togglePause',
+      'selectTrackIndex',
+      'forwardSkip',
+      'backSkip',
+      'seekPreview',
+      'seekComplete',
+      'setVolume',
+      'setVolumeComplete',
+      'toggleMuted',
+      'toggleShuffle',
+      'setRepeatStrategy',
+      'setPlaybackRate',
 
-    // bind audio event listeners to add on mount and remove on unmount
-    this.handleAudioPlay = this.handleAudioPlay.bind(this);
-    this.handleAudioPause = this.handleAudioPause.bind(this);
-    this.handleAudioSrcchange = this.handleAudioSrcchange.bind(this);
-    this.handleAudioEnded = this.handleAudioEnded.bind(this);
-    this.handleAudioStalled = this.handleAudioStalled.bind(this);
-    this.handleAudioCanplaythrough = this.handleAudioCanplaythrough.bind(this);
-    this.handleAudioTimeupdate = this.handleAudioTimeupdate.bind(this);
-    this.handleAudioLoadedmetadata = this.handleAudioLoadedmetadata.bind(this);
-    this.handleAudioVolumechange = this.handleAudioVolumechange.bind(this);
-    this.handleAudioDurationchange = this.handleAudioDurationchange.bind(this);
-    this.handleAudioProgress = this.handleAudioProgress.bind(this);
-    this.handleAudioLoopchange = this.handleAudioLoopchange.bind(this);
-    this.handleAudioRatechange = this.handleAudioRatechange.bind(this);
+      // bind audio event listeners to add on mount and remove on unmount
+      'handleAudioPlay',
+      'handleAudioPause',
+      'handleAudioSrcchange',
+      'handleAudioEnded',
+      'handleAudioStalled',
+      'handleAudioCanplaythrough',
+      'handleAudioTimeupdate',
+      'handleAudioLoadedmetadata',
+      'handleAudioVolumechange',
+      'handleAudioDurationchange',
+      'handleAudioProgress',
+      'handleAudioLoopchange',
+      'handleAudioRatechange'
+    ]);
   }
 
   componentDidMount () {
@@ -174,19 +178,21 @@ class AudioPlayer extends Component {
     audio.playbackRate = this.state.playbackRate;
 
     // add event listeners on the audio element
-    audio.addEventListener('play', this.handleAudioPlay);
-    audio.addEventListener('pause', this.handleAudioPause);
-    audio.addEventListener('srcchange', this.handleAudioSrcchange);
-    audio.addEventListener('ended', this.handleAudioEnded);
-    audio.addEventListener('stalled', this.handleAudioStalled);
-    audio.addEventListener('canplaythrough', this.handleAudioCanplaythrough);
-    audio.addEventListener('timeupdate', this.handleAudioTimeupdate);
-    audio.addEventListener('loadedmetadata', this.handleAudioLoadedmetadata);
-    audio.addEventListener('volumechange', this.handleAudioVolumechange);
-    audio.addEventListener('durationchange', this.handleAudioDurationchange);
-    audio.addEventListener('progress', this.handleAudioProgress);
-    audio.addEventListener('loopchange', this.handleAudioLoopchange);
-    audio.addEventListener('ratechange', this.handleAudioRatechange);
+    addListenersOnObject(this, audio, [
+      ['play', 'handleAudioPlay'],
+      ['pause', 'handleAudioPause'],
+      ['srcchange', 'handleAudioSrcchange'],
+      ['ended', 'handleAudioEnded'],
+      ['stalled', 'handleAudioStalled'],
+      ['canplaythrough', 'handleAudioCanplaythrough'],
+      ['timeupdate', 'handleAudioTimeupdate'],
+      ['loadedmetadata', 'handleAudioLoadedmetadata'],
+      ['volumechange', 'handleAudioVolumechange'],
+      ['durationchange', 'handleAudioDurationchange'],
+      ['progress', 'handleAudioProgress'],
+      ['loopchange', 'handleAudioLoopchange'],
+      ['ratechange', 'handleAudioRatechange']
+    ]);
     this.addMediaEventListeners(this.props.onMediaEvent);
 
     if (isPlaylistValid(this.props.playlist) && this.props.autoplay) {
@@ -288,19 +294,21 @@ class AudioPlayer extends Component {
   componentWillUnmount () {
     const { audio } = this;
     // remove event listeners on the audio element
-    audio.removeEventListener('play', this.handleAudioPlay);
-    audio.removeEventListener('pause', this.handleAudioPause);
-    audio.removeEventListener('srcchange', this.handleAudioSrcchange);
-    audio.removeEventListener('ended', this.handleAudioEnded);
-    audio.removeEventListener('stalled', this.handleAudioStalled);
-    audio.removeEventListener('canplaythrough', this.handleAudioCanplaythrough);
-    audio.removeEventListener('timeupdate', this.handleAudioTimeupdate);
-    audio.removeEventListener('loadedmetadata', this.handleAudioLoadedmetadata);
-    audio.removeEventListener('volumechange', this.handleAudioVolumechange);
-    audio.removeEventListener('durationchange', this.handleAudioDurationchange);
-    audio.removeEventListener('progress', this.handleAudioProgress);
-    audio.removeEventListener('loopchange', this.handleAudioLoopchange);
-    audio.removeEventListener('ratechange', this.handleAudioRatechange);
+    removeListenersOnObject(this, audio, [
+      ['play', 'handleAudioPlay'],
+      ['pause', 'handleAudioPause'],
+      ['srcchange', 'handleAudioSrcchange'],
+      ['ended', 'handleAudioEnded'],
+      ['stalled', 'handleAudioStalled'],
+      ['canplaythrough', 'handleAudioCanplaythrough'],
+      ['timeupdate', 'handleAudioTimeupdate'],
+      ['loadedmetadata', 'handleAudioLoadedmetadata'],
+      ['volumechange', 'handleAudioVolumechange'],
+      ['durationchange', 'handleAudioDurationchange'],
+      ['progress', 'handleAudioProgress'],
+      ['loopchange', 'handleAudioLoopchange'],
+      ['ratechange', 'handleAudioRatechange']
+    ]);
     removeMediaEventListeners(this.props.onMediaEvent);
 
     clearTimeout(this.gapLengthTimeout);

--- a/src/controls/AudioProgress.js
+++ b/src/controls/AudioProgress.js
@@ -6,6 +6,7 @@ import AudioStatusBar from './common/AudioStatusBar';
 import convertToTime from '../utils/convertToTime';
 import getDisplayText from '../utils/getDisplayText';
 import isPlaylistValid from '../utils/isPlaylistValid';
+import bindMethods from '../utils/bindMethods';
 import createControlRenderProp from '../factories/createControlRenderProp';
 
 const audioStatusBarStyle = {
@@ -21,8 +22,10 @@ class AudioProgress extends Component {
   constructor (props) {
     super(props);
 
-    // bind methods fired on React events
-    this.handleSeekPreview = this.handleSeekPreview.bind(this);
+    bindMethods(this, [
+      // bind methods fired on React events
+      'handleSeekPreview'
+    ]);
   }
 
   handleSeekPreview (progress) {

--- a/src/controls/RepeatButton.js
+++ b/src/controls/RepeatButton.js
@@ -5,6 +5,7 @@ import RepeatIcon from 'svg-react-loader?name=RepeatIcon!material-design-icons/a
 import RepeatOneIcon from 'svg-react-loader?name=RepeatOneIcon!material-design-icons/av/svg/design/ic_repeat_one_48px.svg?';
 
 import { repeatStrategyOptions } from '../constants';
+import bindMethods from '../utils/bindMethods';
 import createControlRenderProp from '../factories/createControlRenderProp';
 
 function getNextRepeatStrategy (repeatStrategy) {
@@ -19,8 +20,10 @@ class RepeatButton extends PureComponent {
   constructor (props) {
     super(props);
 
-    // bind methods fired on React events
-    this.handleNextRepeatStrategy = this.handleNextRepeatStrategy.bind(this);
+    bindMethods(this, [
+      // bind methods fired on React events
+      'handleNextRepeatStrategy'
+    ]);
   }
 
   handleNextRepeatStrategy () {

--- a/src/controls/VolumeControl.js
+++ b/src/controls/VolumeControl.js
@@ -7,6 +7,7 @@ import ProgressBar from './common/ProgressBar';
 import getVolumeIconClassName from '../utils/getVolumeIconClassName';
 import getVolumeBarDirectionFromPosition from '../utils/getVolumeBarDirectionFromPosition';
 import stopPropagation from '../utils/reactStopPropagation';
+import bindMethods from '../utils/bindMethods';
 import createControlRenderProp from '../factories/createControlRenderProp';
 
 const volumeControlStyle = {
@@ -37,15 +38,17 @@ class VolumeControl extends PureComponent {
     this.muteToggleRef = null;
     this.volumeBarContainerRef = null;
 
-    // bind methods fired on React events
-    this.setVolumeControlRef = this.setVolumeControlRef.bind(this);
-    this.setMuteToggleRef = this.setMuteToggleRef.bind(this);
-    this.setVolumeBarContainerRef = this.setVolumeBarContainerRef.bind(this);
-    this.handleMouseEnter = this.handleMouseEnter.bind(this);
-    this.handleMouseLeave = this.handleMouseLeave.bind(this);
+    bindMethods(this, [
+      // bind methods fired on React events
+      'setVolumeControlRef',
+      'setMuteToggleRef',
+      'setVolumeBarContainerRef',
+      'handleMouseEnter',
+      'handleMouseLeave',
 
-    // bind listeners to add on mount and remove on unmount
-    this.handleMuteToggleTouchStart = this.handleMuteToggleTouchStart.bind(this);
+      // bind listeners to add on mount and remove on unmount
+      'handleMuteToggleTouchStart'
+    ]);
   }
 
   componentDidMount () {

--- a/src/controls/common/AudioStatusBar.js
+++ b/src/controls/common/AudioStatusBar.js
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import ResizeObserver from 'resize-observer-polyfill';
 
 import getStatusBarSizeClassName from '../../utils/getStatusBarSizeClassName';
+import bindMethods from '../../utils/bindMethods';
 
 class AudioStatusBar extends PureComponent {
   constructor (props) {
@@ -16,11 +17,13 @@ class AudioStatusBar extends PureComponent {
     this.statusBarRef = null;
     this.statusBarResizeObserver = null;
 
-    // bind methods fired on React events
-    this.setStatusBarRef = this.setStatusBarRef.bind(this);
+    bindMethods(this, [
+      // bind methods fired on React events
+      'setStatusBarRef',
 
-    // bind listeners to add on mount and remove on unmount
-    this.handleResize = this.handleResize.bind(this);
+      // bind listeners to add on mount and remove on unmount
+      'handleResize'
+    ]);
   }
 
   componentDidMount () {

--- a/src/controls/common/ProgressBar.js
+++ b/src/controls/common/ProgressBar.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import ProgressBarDisplay from './ProgressBarDisplay';
 import convertToNumberWithinIntervalBounds from '../../utils/convertToNumberWithinIntervalBounds';
+import bindMethods from '../../utils/bindMethods';
 
 class ProgressBar extends PureComponent {
   constructor (props) {
@@ -10,12 +11,14 @@ class ProgressBar extends PureComponent {
 
     this.progressContainer = null;
 
-    // bind methods fired on React events
-    this.setProgressContainerRef = this.setProgressContainerRef.bind(this);
-    this.handleAdjustProgress = this.handleAdjustProgress.bind(this);
+    bindMethods(this, [
+      // bind methods fired on React events
+      'setProgressContainerRef',
+      'handleAdjustProgress',
 
-    // bind listeners to add on mount and remove on unmount
-    this.handleAdjustComplete = this.handleAdjustComplete.bind(this);
+      // bind listeners to add on mount and remove on unmount
+      'handleAdjustComplete'
+    ]);
   }
 
   componentDidMount () {

--- a/src/utils/bindMethods.js
+++ b/src/utils/bindMethods.js
@@ -1,0 +1,7 @@
+function bindMethods(_this, methodNames) {
+  for (const methodName of methodNames) {
+    _this[methodName] = _this[methodName].bind(_this);
+  }
+}
+
+export default bindMethods;

--- a/src/utils/listeners.js
+++ b/src/utils/listeners.js
@@ -1,0 +1,10 @@
+function getListenerUtil (prefix) {
+  return function (obj, element, listeners) {
+    for (const l of listeners) {
+      element[`${prefix}eventListener`](l[0], obj[l[1]]);
+    }
+  }
+}
+
+export const addListenersOnObject = getListenerUtil('add');
+export const removeListenersOnObject = getListenerUtil('remove');


### PR DESCRIPTION
### This should *not* be merged (right now, anyway)

As part of an effort to address #171 I was testing the savings we could get in bundle size if we use util functions to avoid token repetition in function bindings and event listener registration/removal.

At the current moment the savings don't really justify the refactoring:

### Before
Unminified: 169,275 bytes
Minified: 64,198 bytes

### After
Unminified: 170,282 bytes ( *+ ~1kb* )
Minified: 63,330 ( *- <1kb* )

Given that the minified bundle is only 1.4% smaller than before, and the unminified bundle is actually similarly ***larger***, we should probably look for other ways to optimize first.

However, it's clear this technique *would* save a lot of kilobytes if we had a significantly greater number of function bindings and listener registrations per component.