### PR TITLE
Issue/149 multiple audio sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,11 @@ If you prefer not to use a package bundler, you can find built releases to downl
 Options can be passed to the AudioPlayer element as props. Currently supported props are:
 
 * `playlist` (*required*): an array containing data about the tracks which will be played. **undefined** by default. Each track object can contain the following properties:
-  - `url` (*required*): A string containing the address of the audio file to play
+  - `url` (*required*): Can be one of:
+    - A string containing the address of the audio file to play
+    - An array of objects, if you want to specify multiple files of different types for the same track. Each object requires the properties:
+      - `src` (*required*): A string containing the address of a file that can be played for this track
+      - `type` (*required*): A string which is the [audio file's MIME type](https://developer.mozilla.org/en-US/docs/Web/HTML/Supported_media_formats)
   - `title`: The title of the track - corresponds to the [`MediaMetadata.title` property](https://wicg.github.io/mediasession/#examples)
   - `artist`: The track's artist - corresponds to the [`MediaMetadata.artist` property](https://wicg.github.io/mediasession/#examples)
   - `album`: The album the track belongs to - corresponds to the [`MediaMetadata.album` property](https://wicg.github.io/mediasession/#examples)

--- a/src/AudioPlayer.js
+++ b/src/AudioPlayer.js
@@ -823,7 +823,7 @@ AudioPlayer.propTypes = {
       PropTypes.string.isRequired,
       PropTypes.arrayOf(PropTypes.shape({
         src: PropTypes.string.isRequired,
-        type: PropTypes.string
+        type: PropTypes.string.isRequired
       }).isRequired).isRequired
     ]).isRequired,
     title: PropTypes.string.isRequired,

--- a/src/AudioPlayer.js
+++ b/src/AudioPlayer.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import lifecyclesPolyfill from 'react-lifecycles-compat';
+import arrayFindIndex from 'array-find-index';
 
 import PlayerContext from './PlayerContext';
 import AudioControlBar from './controls/AudioControlBar';
@@ -402,7 +403,7 @@ class AudioPlayer extends Component {
   handleAudioSrcrequest (e) {
     const { playlist } = this.props;
     const sources = getTrackSources(playlist, this.state.activeTrackIndex);
-    if (sources.findIndex(source => source.src === e.srcRequested) !== -1) {
+    if (arrayFindIndex(sources, s => s.src === e.srcRequested) !== -1) {
       // we're good! nothing to update.
       return;
     }

--- a/src/controls/AudioProgress.js
+++ b/src/controls/AudioProgress.js
@@ -69,7 +69,7 @@ AudioProgress.propTypes = {
       PropTypes.string.isRequired,
       PropTypes.arrayOf(PropTypes.shape({
         src: PropTypes.string.isRequired,
-        type: PropTypes.string
+        type: PropTypes.string.isRequired
       }).isRequired).isRequired
     ]).isRequired,
     title: PropTypes.string.isRequired,

--- a/src/controls/AudioProgress.js
+++ b/src/controls/AudioProgress.js
@@ -65,7 +65,13 @@ class AudioProgress extends Component {
 
 AudioProgress.propTypes = {
   playlist: PropTypes.arrayOf(PropTypes.shape({
-    url: PropTypes.string.isRequired,
+    url: PropTypes.oneOfType([
+      PropTypes.string.isRequired,
+      PropTypes.arrayOf(PropTypes.shape({
+        src: PropTypes.string.isRequired,
+        type: PropTypes.string
+      }).isRequired).isRequired
+    ]).isRequired,
     title: PropTypes.string.isRequired,
     artist: PropTypes.string,
     album: PropTypes.string,

--- a/src/controls/AudioProgressDisplay.js
+++ b/src/controls/AudioProgressDisplay.js
@@ -38,7 +38,13 @@ class AudioProgressDisplay extends Component {
 
 AudioProgressDisplay.propTypes = {
   playlist: PropTypes.arrayOf(PropTypes.shape({
-    url: PropTypes.string.isRequired,
+    url: PropTypes.oneOfType([
+      PropTypes.string.isRequired,
+      PropTypes.arrayOf(PropTypes.shape({
+        src: PropTypes.string.isRequired,
+        type: PropTypes.string
+      }).isRequired).isRequired
+    ]).isRequired,
     title: PropTypes.string.isRequired,
     artist: PropTypes.string,
     album: PropTypes.string,

--- a/src/controls/AudioProgressDisplay.js
+++ b/src/controls/AudioProgressDisplay.js
@@ -42,7 +42,7 @@ AudioProgressDisplay.propTypes = {
       PropTypes.string.isRequired,
       PropTypes.arrayOf(PropTypes.shape({
         src: PropTypes.string.isRequired,
-        type: PropTypes.string
+        type: PropTypes.string.isRequired
       }).isRequired).isRequired
     ]).isRequired,
     title: PropTypes.string.isRequired,

--- a/src/utils/findTrackIndexByUrl.js
+++ b/src/utils/findTrackIndexByUrl.js
@@ -1,7 +1,13 @@
 import arrayFindIndex from 'array-find-index';
 
 function findTrackIndexByUrl (playlist, url) {
-  return arrayFindIndex(playlist, track => track.url && url === track.url);
+  return arrayFindIndex(playlist, track => {
+    return track.url && (
+      track.url.constructor === Array
+        ? track.url.findIndex(source => source.src === url) !== -1
+        : url === track.url
+    );
+  });
 }
 
 export default findTrackIndexByUrl;

--- a/src/utils/getTrackSources.js
+++ b/src/utils/getTrackSources.js
@@ -1,0 +1,12 @@
+import isPlaylistValid from './isPlaylistValid';
+
+function getTrackSources (playlist, index) {
+  const url = isPlaylistValid(playlist) && (playlist[index] || {}).url || '';
+  return (
+    url.constructor === Array
+      ? (url.length ? url : '')
+      : [{ src: url }]
+  );
+}
+
+export default getTrackSources;

--- a/src/utils/getTrackSrc.js
+++ b/src/utils/getTrackSrc.js
@@ -1,8 +1,0 @@
-import isPlaylistValid from './isPlaylistValid';
-
-function getTrackSrc (playlist, index) {
-  const url = isPlaylistValid(playlist) && (playlist[index] || {}).url || '';
-  return url.constructor === Array && url.length ? url : [{ src: url }];
-}
-
-export default getTrackSrc;

--- a/src/utils/getTrackSrc.js
+++ b/src/utils/getTrackSrc.js
@@ -1,7 +1,8 @@
 import isPlaylistValid from './isPlaylistValid';
 
 function getTrackSrc (playlist, index) {
-  return isPlaylistValid(playlist) && (playlist[index] || {}).url || '';
+  const url = isPlaylistValid(playlist) && (playlist[index] || {}).url || '';
+  return url.constructor === Array && url.length ? url : [{ src: url }];
 }
 
 export default getTrackSrc;


### PR DESCRIPTION
Closes #149.

* Instead of setting `src` on `<audio>` element itself we are setting `src` on `<source>` children of the audio element
* Remove `srcchange` event (on src mutation completed)
* Add `srcrequest` event (we block attempts to mutate `audio.src` and fire this instead)
* When a `srcrequest` event is fired, we:
  - Try to find a track index that matches the src
  - If we're successful, we change the active track index
  - The newly updated `<source>` elements are responsible for determining which src we *actually* load
* Reading `audio.src` now just returns the value of `audio.currentSrc`