### PR TITLE
Issue/179 sources prop type

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,11 +110,10 @@ If you prefer not to use a package bundler, you can find built releases to downl
 Options can be passed to the AudioPlayer element as props. Currently supported props are:
 
 * `playlist` (*required*): an array containing data about the tracks which will be played. **undefined** by default. Each track object can contain the following properties:
-  - `url` (*required*): Can be one of:
-    - A string containing the address of the audio file to play
-    - An array of objects, if you want to specify multiple files of different types for the same track. Each object requires the properties:
-      - `src` (*required*): A string containing the address of a file that can be played for this track
-      - `type` (*required*): A string which is the [audio file's MIME type](https://developer.mozilla.org/en-US/docs/Web/HTML/Supported_media_formats)
+  - `url` (*required* unless `sources` is specified): A string containing the address of the audio file to play
+  - `sources` (*required* unless `url` is specified): An array of objects, if you want to specify multiple files of different types for the same track. Each object requires the properties:
+    - `src` (*required*): A string containing the address of a file that can be played for this track
+    - `type` (*required*): A string which is the [audio file's MIME type](https://developer.mozilla.org/en-US/docs/Web/HTML/Supported_media_formats)
   - `title`: The title of the track - corresponds to the [`MediaMetadata.title` property](https://wicg.github.io/mediasession/#examples)
   - `artist`: The track's artist - corresponds to the [`MediaMetadata.artist` property](https://wicg.github.io/mediasession/#examples)
   - `album`: The album the track belongs to - corresponds to the [`MediaMetadata.album` property](https://wicg.github.io/mediasession/#examples)

--- a/src/AudioPlayer.js
+++ b/src/AudioPlayer.js
@@ -17,13 +17,10 @@ import getDisplayText from './utils/getDisplayText';
 import getRepeatStrategy from './utils/getRepeatStrategy';
 import getControlRenderProp from './utils/getControlRenderProp';
 import convertToNumberWithinIntervalBounds from './utils/convertToNumberWithinIntervalBounds';
+import { logError, logWarning } from './utils/console';
 import { repeatStrategyOptions } from './constants';
 
 import './styles/index.scss';
-
-const log = console.log.bind(console);
-const logError = console.error ? console.error.bind(console) : log;
-const logWarning = console.warn ? console.warn.bind(console) : log;
 
 let nextControlKey = 0;
 function getNextControlKey () {

--- a/src/AudioPlayer.js
+++ b/src/AudioPlayer.js
@@ -270,18 +270,19 @@ class AudioPlayer extends Component {
       allowBackShuffle: this.props.allowBackShuffle
     });
 
-    if (!this.state.shuffle) {
-      const prevSources = getTrackSources(
-        prevProps.playlist,
-        prevState.activeTrackIndex
-      );
-      const newSources = getTrackSources(
-        this.props.playlist,
-        this.state.activeTrackIndex
-      );
-      if (prevSources[0].src !== newSources[0].src) {
-        // cancel playback and re-scan current sources
-        this.audio.load();
+    const prevSources = getTrackSources(
+      prevProps.playlist,
+      prevState.activeTrackIndex
+    );
+    const newSources = getTrackSources(
+      this.props.playlist,
+      this.state.activeTrackIndex
+    );
+    if (prevSources[0].src !== newSources[0].src) {
+      // cancel playback and re-scan current sources
+      this.audio.load();
+
+      if (!this.state.shuffle) {
         // after toggling off shuffle, we defer clearing the shuffle
         // history until we actually change tracks - if the user quickly
         // toggles  shuffle off then back on again, we don't want to have

--- a/src/utils/console.js
+++ b/src/utils/console.js
@@ -1,0 +1,3 @@
+export const log = console.log.bind(console);
+export const logError = console.error ? console.error.bind(console) : log;
+export const logWarning = console.warn ? console.warn.bind(console) : log;

--- a/src/utils/findTrackIndexByUrl.js
+++ b/src/utils/findTrackIndexByUrl.js
@@ -2,11 +2,10 @@ import arrayFindIndex from 'array-find-index';
 
 function findTrackIndexByUrl (playlist, url) {
   return arrayFindIndex(playlist, track => {
-    return track.url && (
-      track.url.constructor === Array
-        ? track.url.findIndex(source => source.src === url) !== -1
-        : url === track.url
-    );
+    if (track.sources) {
+      return arrayFindIndex(track.sources, source => source.src === url) !== -1;
+    }
+    return track.url && url === track.url;
   });
 }
 

--- a/src/utils/getSourceList.js
+++ b/src/utils/getSourceList.js
@@ -1,5 +1,9 @@
+import getTrackSources from './getTrackSources';
+
+// collapses playlist into flat list containing
+// the first source url for each track
 function getSourceList (playlist) {
-  return (playlist || []).map(track => track.url);
+  return (playlist || []).map((_, i) => getTrackSources(playlist, i)[0].src);
 }
 
 export default getSourceList;

--- a/src/utils/getTrackSources.js
+++ b/src/utils/getTrackSources.js
@@ -1,12 +1,16 @@
 import isPlaylistValid from './isPlaylistValid';
 
+const blankSources = [{ src: '' }];
+
 function getTrackSources (playlist, index) {
-  const url = isPlaylistValid(playlist) && (playlist[index] || {}).url || '';
-  return (
-    url.constructor === Array
-      ? (url.length ? url : '')
-      : [{ src: url }]
-  );
+  if (!isPlaylistValid(playlist)) {
+    return blankSources;
+  }
+  const { sources, url } = playlist[index];
+  if (sources) {
+    return sources.length ? sources : blankSources;
+  }
+  return [{ src: url }];
 }
 
 export default getTrackSources;


### PR DESCRIPTION
Closes #179.

* Instead of optionally passing a list of source objects for `url`, you have to use a separate property on a playlist track, `sources`.
* You need to define *either* `url` *or* `sources`, but not both (or else there will be a console warning).
* A couple bugs addressed:
  - `getSourceList` was neglected before when we introduced the option to specify many sources. Fixed!
  - `We weren't ever changing tracks when in shuffle mode, by accident. Fixed!