### PR TITLE
volume control fix on scroll

### DIFF
--- a/packages/components/src/utils/observeProgressBarRect.js
+++ b/packages/components/src/utils/observeProgressBarRect.js
@@ -111,13 +111,13 @@ function updateScroll() {
   scrollTop = supportPageOffset
     ? window.pageYOffset
     : isCSS1Compat
-    ? document.documentElement.scrollTop  
-    : document.body.scrollTop;  
+    ? document.documentElement.scrollTop
+    : document.body.scrollTop;
   scrollLeft = supportPageOffset
     ? window.pageXOffset
     : isCSS1Compat
-    ? document.documentElement.scrollLeft  
-    : document.body.scrollLeft;  
+    ? document.documentElement.scrollLeft
+    : document.body.scrollLeft;
 }
 
 function onTransitionend({ propertyName = '' }) {

--- a/packages/components/src/utils/observeProgressBarRect.js
+++ b/packages/components/src/utils/observeProgressBarRect.js
@@ -106,8 +106,10 @@ function refresh() {
 }
 
 function updateScroll() {
-  scrollTop = document.body.scrollTop;
-  scrollLeft = document.body.scrollLeft;
+  const supportPageOffset = window.pageXOffset !== undefined;
+  const isCSS1Compat = ((document.compatMode || "") === "CSS1Compat");
+  scrollTop = supportPageOffset ? window.pageYOffset : isCSS1Compat ? document.documentElement.scrollTop : document.body.scrollTop;
+  scrollLeft = supportPageOffset ? window.pageXOffset : isCSS1Compat ? document.documentElement.scrollLeft : document.body.scrollLeft;
 }
 
 function onTransitionend({ propertyName = '' }) {

--- a/packages/components/src/utils/observeProgressBarRect.js
+++ b/packages/components/src/utils/observeProgressBarRect.js
@@ -107,9 +107,17 @@ function refresh() {
 
 function updateScroll() {
   const supportPageOffset = window.pageXOffset !== undefined;
-  const isCSS1Compat = ((document.compatMode || "") === "CSS1Compat");
-  scrollTop = supportPageOffset ? window.pageYOffset : isCSS1Compat ? document.documentElement.scrollTop : document.body.scrollTop;
-  scrollLeft = supportPageOffset ? window.pageXOffset : isCSS1Compat ? document.documentElement.scrollLeft : document.body.scrollLeft;
+  const isCSS1Compat = (document.compatMode || '') === 'CSS1Compat';
+  scrollTop = supportPageOffset
+    ? window.pageYOffset
+    : isCSS1Compat
+    ? document.documentElement.scrollTop
+    : document.body.scrollTop;
+  scrollLeft = supportPageOffset
+    ? window.pageXOffset
+    : isCSS1Compat
+    ? document.documentElement.scrollLeft
+    : document.body.scrollLeft;
 }
 
 function onTransitionend({ propertyName = '' }) {

--- a/packages/components/src/utils/observeProgressBarRect.js
+++ b/packages/components/src/utils/observeProgressBarRect.js
@@ -107,16 +107,9 @@ function refresh() {
 
 function updateScroll() {
   const supportPageOffset = window.pageXOffset !== undefined;
-  const isCSS1Compat = (document.compatMode || '') === 'CSS1Compat';
-  scrollTop = supportPageOffset
-    ? window.pageYOffset
-    : isCSS1Compat
-    ? document.documentElement.scrollTop
-    : document.body.scrollTop;
+  scrollTop = supportPageOffset ? window.pageYOffset : document.body.scrollTop;
   scrollLeft = supportPageOffset
     ? window.pageXOffset
-    : isCSS1Compat
-    ? document.documentElement.scrollLeft
     : document.body.scrollLeft;
 }
 

--- a/packages/components/src/utils/observeProgressBarRect.js
+++ b/packages/components/src/utils/observeProgressBarRect.js
@@ -111,13 +111,13 @@ function updateScroll() {
   scrollTop = supportPageOffset
     ? window.pageYOffset
     : isCSS1Compat
-    ? document.documentElement.scrollTop
-    : document.body.scrollTop;
+    ? document.documentElement.scrollTop  
+    : document.body.scrollTop;  
   scrollLeft = supportPageOffset
     ? window.pageXOffset
     : isCSS1Compat
-    ? document.documentElement.scrollLeft
-    : document.body.scrollLeft;
+    ? document.documentElement.scrollLeft  
+    : document.body.scrollLeft;  
 }
 
 function onTransitionend({ propertyName = '' }) {


### PR DESCRIPTION
According to MDN: For cross-browser compatibility, use window.pageYOffset instead of window.scrollY. Additionally, older versions of Internet Explorer (< 9) do not support either property and must be worked around by checking other non-standard properties. A fully compatible example:

`var supportPageOffset = window.pageXOffset !== undefined;
var isCSS1Compat = ((document.compatMode || "") === "CSS1Compat");

var x = supportPageOffset ? window.pageXOffset : isCSS1Compat ? document.documentElement.scrollLeft : document.body.scrollLeft;
var y = supportPageOffset ? window.pageYOffset : isCSS1Compat ? document.documentElement.scrollTop : document.body.scrollTop; `

[https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY#Notes](url)

Tested on Firefox, Chrome, Safari, Edge and Internet Explore